### PR TITLE
fix: do not override existing AWS credentials in env

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -10,6 +10,11 @@ export default (withConfigDir: string): void => {
   process.env.MOCK_DYNAMODB_ENDPOINT = `localhost:${port}`;
 
   // aws-sdk requires access and secret key to be able to call DDB
-  process.env.AWS_ACCESS_KEY_ID = "access-key";
-  process.env.AWS_SECRET_ACCESS_KEY = "secret-key";
+  if (!process.env.AWS_ACCESS_KEY_ID) {
+    process.env.AWS_ACCESS_KEY_ID = "access-key";
+  }
+
+  if (!process.env.AWS_SECRET_ACCESS_KEY) {
+    process.env.AWS_SECRET_ACCESS_KEY = "secret-key";
+  }
 };


### PR DESCRIPTION
We're running both jest-dynalite for unit tests together with a real DynamoDB instance for E2E tests.

Setting jest-dynalite as a jest testEnvironment overwrites our existing AWS credentials saved in the process environment.
This PR makes sure `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not overwritten if they exist.