### PR TITLE
Fail hard when no config file is found

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,8 +7,12 @@ interface Config {
   basePort?: number;
 }
 
-const loadConfig = (configFile: string): Config =>
-  fs.existsSync(configFile) ? require(configFile) : {}; // eslint-disable-line import/no-dynamic-require, global-require
+const loadConfig = (configFile: string): Config => {
+  if (fs.existsSync(configFile)) {
+    return require(configFile); // eslint-disable-line import/no-dynamic-require, global-require
+  }
+  throw new Error("Could not find 'jest-dynalite-config.js' file");
+};
 
 const configFile = (configDir: string): string =>
   resolve(configDir, "jest-dynalite-config.js");


### PR DESCRIPTION
When I started using this module I placed the config file in the wrong directory by mistake, and, due to how this module currently works (a default empty config is used if none is found), this lead to the module seemingly working fine but failing in some dynamo calls due to missing tables, which were described in my config file.
In my opinion, it's better to just fail hard and let the user know about the problem, as that would have saved me some time spent debugging.