### PR TITLE
fix: prevent preset conflicting with advanced config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "deno.enable": false
 }

--- a/jest-advanced-with-environment.config.js
+++ b/jest-advanced-with-environment.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: "<rootDir>/dist/environment",
+  setupFiles: ["<rootDir>/setupTests/setupAdvanced.js"],
+  setupFilesAfterEnv: ["<rootDir>/setupTests/setupSimple.js"]
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-dynalite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Run your tests using Jest & Dynalite",
   "license": "MIT",
   "repository": "https://github.com/freshollie/jest-dynalite",
@@ -19,8 +19,9 @@
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "test": "jest",
     "test:environment": "yarn pretest && jest -c jest-environment.config.js",
+    "test:advanced-environment": "yarn pretest && jest -c jest-advanced-with-environment.config.js",
     "test:advanced": "yarn pretest && jest -c jest-advanced.config.js",
-    "test:all": "yarn pretest && jest && jest -c jest-environment.config.js && jest -c jest-advanced.config.js",
+    "test:all": "yarn pretest && jest && jest -c jest-environment.config.js && jest -c jest-advanced.config.js && jest -c jest-advanced-with-environment.config.js",
     "build": "rm -rf dist && tsc",
     "pretest": "yarn build",
     "prepare": "yarn build"

--- a/src/db.ts
+++ b/src/db.ts
@@ -102,13 +102,19 @@ const waitForDeleted = async (
   }
 };
 
-export const start = (): Promise<void> =>
-  new Promise(resolve =>
-    dynaliteInstance.listen(process.env.MOCK_DYNAMODB_PORT, resolve)
-  );
+export const start = async (): Promise<void> => {
+  if (!dynaliteInstance.listening) {
+    await new Promise(resolve =>
+      dynaliteInstance.listen(process.env.MOCK_DYNAMODB_PORT, resolve)
+    );
+  }
+};
 
-export const stop = (): Promise<void> =>
-  new Promise(resolve => dynaliteInstance.close(() => resolve()));
+export const stop = async (): Promise<void> => {
+  if (dynaliteInstance.listening) {
+    await new Promise(resolve => dynaliteInstance.close(() => resolve()));
+  }
+};
 
 export const deleteTables = async (): Promise<void> =>
   runWithRealTimers(async () => {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,13 +1,15 @@
 import NodeEnvironment from "jest-environment-node";
 import { Config } from "@jest/types";
-import setup from "./setup";
+import setup, { isSetup } from "./setup";
 import { start, stop } from "./db";
 
 export default class DynaliteEnvironment extends NodeEnvironment {
   constructor(projectConfig: Config.ProjectConfig) {
     // The config directory is based on the root directory
     // of the project config
-    setup(projectConfig.rootDir);
+    if (!isSetup()) {
+      setup(projectConfig.rootDir);
+    }
 
     super(projectConfig);
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,11 @@
 import { setConfigDir, getDynalitePort } from "./config";
 
+let called = false;
+
+export const isSetup = (): boolean => called;
+
 export default (withConfigDir: string): void => {
+  called = true;
   setConfigDir(withConfigDir);
 
   const port = getDynalitePort();


### PR DESCRIPTION
> Prevent multiple dynalite instances from trying to start when using preset alongside setupFiles method

Fix for : #6 