### PR TITLE
feat: allow fixture data to be configured as part of table creation

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,8 +71,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Test example
         run: |
+          yarn
           cd example 
-          yarn --frozen-lockfile
+          yarn
           yarn test
         env:
           CI: true

--- a/.jest/configs/tables-function-async/jest-dynalite-config.js
+++ b/.jest/configs/tables-function-async/jest-dynalite-config.js
@@ -1,20 +1,12 @@
+const tables = require("../tables");
+
 const realTimeout = setTimeout;
 const sleep = time => new Promise(resolve => realTimeout(resolve, time));
 
 module.exports = {
   tables: async () => {
     await sleep(300);
-    return [
-      {
-        TableName: "files",
-        KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-        AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-        ProvisionedThroughput: {
-          ReadCapacityUnits: 1,
-          WriteCapacityUnits: 1
-        }
-      }
-    ];
+    return tables;
   },
   basePort: 8000
 };

--- a/.jest/configs/tables-function/jest-dynalite-config.js
+++ b/.jest/configs/tables-function/jest-dynalite-config.js
@@ -1,14 +1,6 @@
+const tables = require("../tables");
+
 module.exports = {
-  tables: () => [
-    {
-      TableName: "files",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: 1
-      }
-    }
-  ],
+  tables: () => tables,
   basePort: 8000
 };

--- a/.jest/configs/tables.js
+++ b/.jest/configs/tables.js
@@ -1,0 +1,32 @@
+module.exports = [
+  {
+    TableName: "files",
+    KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 1,
+      WriteCapacityUnits: 1
+    }
+  },
+  {
+    TableName: "images",
+    KeySchema: [{ AttributeName: "url", KeyType: "HASH" }],
+    AttributeDefinitions: [{ AttributeName: "url", AttributeType: "S" }],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 1,
+      WriteCapacityUnits: 1
+    },
+    data: [
+      {
+        url: "https://something.com/something/image.jpg",
+        width: 100,
+        height: 200
+      },
+      {
+        url: "https://something.com/something/image2.jpg",
+        width: 150,
+        height: 250
+      }
+    ]
+  }
+];

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "deno.enable": false
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/node_modules": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ module.exports = {
 };
 ```
 
+Some data can be given to exist in the table before each test:
+
+```js
+module.exports = {
+  tables: [
+    {
+      TableName: "table",
+      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1
+      },
+      data: [
+        {
+          id: "a",
+          someattribute: "hello world"
+        }
+      ]
+    }
+  ],
+  basePort: 8000
+};
+```
+
 Your tables can also be resolved from an optionally async function:
 
 ```js

--- a/example/jest-dynalite-config.js
+++ b/example/jest-dynalite-config.js
@@ -1,13 +1,19 @@
 module.exports = {
   tables: [
     {
-      TableName: "files",
+      TableName: "keys",
       KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
       AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
       ProvisionedThroughput: {
         ReadCapacityUnits: 1,
         WriteCapacityUnits: 1
-      }
+      },
+      data: [
+        {
+          id: "50",
+          value: { name: "already exists" }
+        }
+      ]
     }
   ],
   basePort: 8000

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
     },
     "devDependencies": {
         "jest": "^26.5.2",
-        "jest-dynalite": "^3.0.0"
+        "jest-dynalite": "file:../"
     },
     "dependencies": {
         "aws-sdk": "^2.771.0"

--- a/example/src/keystore.js
+++ b/example/src/keystore.js
@@ -10,11 +10,11 @@ const ddb = new DocumentClient({
 module.exports = {
   getItem: async byId => {
     const { Item } = await ddb
-      .get({ TableName: "files", Key: { id: byId } })
+      .get({ TableName: "keys", Key: { id: byId } })
       .promise();
 
     return Item && Item.value;
   },
   putItem: (id, value) =>
-    ddb.put({ TableName: "files", Item: { id, value } }).promise()
+    ddb.put({ TableName: "keys", Item: { id, value } }).promise()
 };

--- a/example/src/keystore.test.js
+++ b/example/src/keystore.test.js
@@ -14,4 +14,8 @@ describe("keystore", () => {
   it("should handle no value for key", async () => {
     expect(await keystore.getItem("a")).toBeUndefined();
   });
+
+  it("should contain the existing key from example data", async () => {
+    expect(await keystore.getItem("50")).toEqual({ name: "already exists" });
+  });
 });

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2268,10 +2268,8 @@ jest-docblock@^26.0.0:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-dynalite@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jest-dynalite/-/jest-dynalite-3.0.0.tgz#d562ef3d475239b1a1e9745fb7262baeda08c24c"
-  integrity sha512-x63pCfdPfujYJ+2l739pj3NMlMz5SStvKn5MItcT/GRbwjsyvZe/3OVCNpD0Kbv3aoZn91kQesFDSujMwBT62g==
+"jest-dynalite@file:..":
+  version "3.1.0"
   dependencies:
     "@jest/types" "^24.9.0"
     dynalite "^3.0.0"

--- a/jest-dynalite-config.js
+++ b/jest-dynalite-config.js
@@ -1,16 +1,8 @@
+const tables = require("./.jest/configs/tables");
+
 // This is the simple jest-dynalite config used by most tests
 // More advanced test configs can be found in .jest/configs
 module.exports = {
-  tables: [
-    {
-      TableName: "files",
-      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
-      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: 1,
-        WriteCapacityUnits: 1
-      }
-    }
-  ],
+  tables,
   basePort: 8000
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,35 @@ export const isPromise = <R>(p: unknown | Promise<R>): p is Promise<R> =>
 
 export const isFunction = <F>(f: unknown | (() => F)): f is () => F =>
   f && typeof f === "function";
+
+interface Omit {
+  <T extends object, K extends [...(keyof T)[]]>(obj: T, ...keys: K): {
+    [K2 in Exclude<keyof T, K[number]>]: T[K2];
+  };
+}
+
+const convertToNumbers = (
+  keys: Array<string | number | symbol>,
+  value: string | number
+): number | string => {
+  if (!Number.isNaN(Number(value)) && keys.some(v => v === Number(value))) {
+    return Number(value);
+  }
+
+  return value;
+};
+
+// credit: https://stackoverflow.com/a/62362002/1741602
+export const omit = <T, K extends [...(keyof T)[]]>(
+  obj: T,
+  ...keys: K
+): { [P in Exclude<keyof T, K[number]>]: T[P] } => {
+  return (Object.getOwnPropertySymbols(obj) as Array<keyof T>)
+    .concat(
+      Object.keys(obj).map(key => convertToNumbers(keys, key)) as Array<keyof T>
+    )
+    .filter(key => !keys.includes(key))
+    .reduce((agg, key) => ({ ...agg, [key]: obj[key] }), {}) as {
+    [P in Exclude<keyof T, K[number]>]: T[P];
+  };
+};

--- a/tests/table-data.test.js
+++ b/tests/table-data.test.js
@@ -1,0 +1,65 @@
+const { DocumentClient } = require("aws-sdk/clients/dynamodb");
+
+const ddb = new DocumentClient({
+  convertEmptyValues: true,
+  endpoint: process.env.MOCK_DYNAMODB_ENDPOINT,
+  sslEnabled: false,
+  region: "local"
+});
+
+it("should contain table data provided in config", async () => {
+  {
+    const { Item } = await ddb
+      .get({
+        TableName: "images",
+        Key: { url: "https://something.com/something/image.jpg" }
+      })
+      .promise();
+
+    expect(Item).toEqual({
+      url: "https://something.com/something/image.jpg",
+
+      width: 100,
+      height: 200
+    });
+  }
+  {
+    const { Item } = await ddb
+      .get({
+        TableName: "images",
+        Key: { url: "https://something.com/something/image2.jpg" }
+      })
+      .promise();
+
+    expect(Item).toEqual({
+      url: "https://something.com/something/image2.jpg",
+      width: 150,
+      height: 250
+    });
+  }
+});
+
+it("should ensure that data is recreated after each test", async () => {
+  await ddb
+    .delete({
+      TableName: "images",
+      Key: { url: "https://something.com/something/image2.jpg" }
+    })
+    .promise();
+});
+
+// This test must follow the previous
+it("should ensure that data is recreated after each test", async () => {
+  const { Item } = await ddb
+    .get({
+      TableName: "images",
+      Key: { url: "https://something.com/something/image2.jpg" }
+    })
+    .promise();
+
+  expect(Item).toEqual({
+    url: "https://something.com/something/image2.jpg",
+    width: 150,
+    height: 250
+  });
+});


### PR DESCRIPTION
This PR allows data to be configured as part of the configuration for each table.

Example:

```js
module.exports = {
  tables: [
    {
      TableName: "table",
      KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
      AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
      ProvisionedThroughput: {
        ReadCapacityUnits: 1,
        WriteCapacityUnits: 1
      },
      data: [
        {
          "id": "a",
          "someattribute": "hello world"
        }
      ]
    }
  ],
  basePort: 8000
};
```

This is an optional parameter, so this isn't a breaking change.