### PR TITLE
fix: stops return NaN as a Dynalite port from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ module.exports = {
 
 **IMPORTANT NOTE**
 
-Be aware that the only one instance of dynalite will start.
+Be aware that the only one instance of dynalite will start, which may cause test issues if multiple runners are editing the same data.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ module.exports = {
 }
 ```
 
-#### One dynalite instance
-
 This setup should be used if you want to override the default config of `clearAfterEach`, but still want to use the most simple configuration.
+
+#### One dynalite instance
 
 If you want to start & setup the db **only** once for all your suites,
 create a `setup.js` and `teardown.js` files with the following content:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,50 @@ afterEach(deleteTables);
 afterAll(stopDb);
 ```
 
+If you want to start & setup the db **only** once for all your suites,
+create a `setup.js` and `teardown.js` files with the following content:
+
+```javascript
+// setup.js
+
+import { startDb, createTables } from "jest-dynalite";
+
+module.exports = async () => {
+  // You must provide a config directory
+  setup(__dirname);
+  await startDb();
+  await createTables();
+};
+```
+
+```javascript
+// teardown.js
+
+import { stopDb, deleteTables } from "jest-dynalite";
+
+module.exports = async function () {
+  // Cleanup after tests
+  await deleteTables();
+  await stopDb();
+};
+```
+
+You then must add the setup files to your jest config
+
+jest.config.js
+
+```javascript
+module.exports = {
+  ...
+  globalSetup: ["./setup.js"],
+  globalTeardown: ["./teardown.js"],
+}
+```
+
+**IMPORTANT NOTE**
+
+Be aware that the only one instance of dynalite will start.
+
 ### Other options
 
 jest.config.js

--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ afterEach(deleteTables);
 afterAll(stopDb);
 ```
 
+### Other options
+
+jest.config.js
+
+```javascript
+module.exports = {
+  ...
+  testEnvironment: "jest-dynalite/environment",
+
+  setupFilesAfterEnv: [
+    "jest-dynalite/setupTables",
+    // Optional (but recommended)
+    "jest-dynalite/clearAfterEach"
+  ]
+}
+```
+
+#### One dynalite instance
+
+This setup should be used if you want to override the default config of `clearAfterEach`, but still want to use the most simple configuration.
+
 If you want to start & setup the db **only** once for all your suites,
 create a `setup.js` and `teardown.js` files with the following content:
 
@@ -274,25 +295,6 @@ module.exports = {
 **IMPORTANT NOTE**
 
 Be aware that the only one instance of dynalite will start.
-
-### Other options
-
-jest.config.js
-
-```javascript
-module.exports = {
-  ...
-  testEnvironment: "jest-dynalite/environment",
-
-  setupFilesAfterEnv: [
-    "jest-dynalite/setupTables",
-    // Optional (but recommended)
-    "jest-dynalite/clearAfterEach"
-  ]
-}
-```
-
-This setup should be used if you want to override the default config of `clearAfterEach`, but still want to use the most simple configuration.
 
 ## Development
 

--- a/src/__testdir__/defined-basePort/jest-dynalite-config.ts
+++ b/src/__testdir__/defined-basePort/jest-dynalite-config.ts
@@ -1,7 +1,0 @@
-export const BASE_PORT = 10500;
-
-// fake config
-export default {
-  tables: [],
-  basePort: BASE_PORT,
-};

--- a/src/__testdir__/defined-basePort/jest-dynalite-config.ts
+++ b/src/__testdir__/defined-basePort/jest-dynalite-config.ts
@@ -1,0 +1,7 @@
+export const BASE_PORT = 10500;
+
+// fake config
+export default {
+  tables: [],
+  basePort: BASE_PORT,
+};

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,0 +1,40 @@
+import { join } from "path";
+import { getDynalitePort, setConfigDir } from "./config";
+import { BASE_PORT } from "./__testdir__/defined-basePort/jest-dynalite-config";
+
+const DEFAULT_BASE_PORT = 8000;
+
+describe("Config", () => {
+  const configDirectory = join(__dirname, "__testdir__", "defined-basePort");
+
+  beforeAll(() => {
+    setConfigDir(configDirectory);
+  });
+
+  it("a different port is returned for each worker", () => {
+    const expectedPort =
+      BASE_PORT + parseInt(process.env.JEST_WORKER_ID as string, 10);
+
+    expect(getDynalitePort()).toBe(expectedPort);
+  });
+
+  it("should return dynalite port even there is no JEST_WORKER_ID", () => {
+    const workerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
+    const port = getDynalitePort();
+
+    expect(port).not.toBeNaN();
+    expect(getDynalitePort()).toBe(BASE_PORT);
+
+    process.env.JEST_WORKER_ID = workerId;
+  });
+
+  it("if basePort is not defined then port 8000 will be used as a default", () => {
+    setConfigDir(join(__dirname, "__testdir__"));
+    const expectedPort =
+      DEFAULT_BASE_PORT + parseInt(process.env.JEST_WORKER_ID as string, 10);
+
+    expect(getDynalitePort()).toBe(expectedPort);
+  });
+});

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,39 +1,55 @@
-import { join } from "path";
+import fs from "fs";
+import { Config } from "./types";
 import { getDynalitePort, setConfigDir } from "./config";
-import { BASE_PORT } from "./__testdir__/defined-basePort/jest-dynalite-config";
 
+const BASE_PORT = 8443;
 const DEFAULT_BASE_PORT = 8000;
 
-describe("Config", () => {
-  const configDirectory = join(__dirname, "__testdir__", "defined-basePort");
+const mockedConfig = jest.fn((): Config => ({ basePort: BASE_PORT }));
+const configPath = "/fakepath/jest-dynalite-config.js";
 
+jest.mock("fs");
+(fs.existsSync as jest.Mock).mockReturnValue(true);
+
+jest.mock("path", () => {
+  const original = jest.requireActual("path");
+  return {
+    ...original,
+    resolve: jest.fn(() => configPath),
+  };
+});
+
+jest.mock(configPath, () => mockedConfig(), { virtual: true });
+
+describe("Config", () => {
   beforeAll(() => {
-    setConfigDir(configDirectory);
+    setConfigDir("/whatever");
   });
 
-  it("a different port is returned for each worker", () => {
+  test("a different port is returned for each worker", () => {
     const expectedPort =
       BASE_PORT + parseInt(process.env.JEST_WORKER_ID as string, 10);
 
     expect(getDynalitePort()).toBe(expectedPort);
   });
 
-  it("should return dynalite port even there is no JEST_WORKER_ID", () => {
+  test("should return dynalite port even there is no JEST_WORKER_ID", () => {
     const workerId = process.env.JEST_WORKER_ID;
     delete process.env.JEST_WORKER_ID;
 
     const port = getDynalitePort();
 
     expect(port).not.toBeNaN();
-    expect(getDynalitePort()).toBe(BASE_PORT);
+    expect(port).toBe(BASE_PORT);
 
     process.env.JEST_WORKER_ID = workerId;
   });
 
-  it("if basePort is not defined then port 8000 will be used as a default", () => {
-    setConfigDir(join(__dirname, "__testdir__"));
+  test("if basePort is not defined then port 8000 will be used as a default", () => {
+    jest.resetModules();
+    mockedConfig.mockReturnValue({});
     const expectedPort =
-      DEFAULT_BASE_PORT + parseInt(process.env.JEST_WORKER_ID as string, 10);
+      DEFAULT_BASE_PORT + parseInt(process.env.JEST_WORKER_ID || "0", 10);
 
     expect(getDynalitePort()).toBe(expectedPort);
   });

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -53,4 +53,12 @@ describe("Config", () => {
 
     expect(getDynalitePort()).toBe(expectedPort);
   });
+
+  test("should throw an error if basePort in config file is invalid", () => {
+    jest.resetModules();
+    // @ts-ignore
+    mockedConfig.mockReturnValue({ basePort: "this is not a number" });
+
+    expect(getDynalitePort).toThrowError(TypeError);
+  });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,8 +63,7 @@ export const setConfigDir = (directory: string): void => {
 export const getDynalitePort = (): number => {
   const config = readConfig();
   return (
-    (config.basePort ?? 8000) +
-    parseInt(process.env.JEST_WORKER_ID as string, 10)
+    (config.basePort ?? 8000) + parseInt(process.env.JEST_WORKER_ID || "0", 10)
   );
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,9 +61,13 @@ export const setConfigDir = (directory: string): void => {
 };
 
 export const getDynalitePort = (): number => {
-  const config = readConfig();
-  return (
-    (config.basePort ?? 8000) + parseInt(process.env.JEST_WORKER_ID || "0", 10)
+  const { basePort = 8000 } = readConfig();
+  if (Number.isInteger(basePort) && basePort > 0 && basePort <= 65535) {
+    return basePort + parseInt(process.env.JEST_WORKER_ID || "0", 10);
+  }
+
+  throw new TypeError(
+    `Option "basePort" must be an number between 1 and 65535. Received "${basePort.toString()}"`
   );
 };
 


### PR DESCRIPTION
Given you want to start & setup dynalite only **once** before all test cases. 
Then you need to use [jest option named `globalSetup`](https://jestjs.io/docs/25.x/configuration#globalsetup-string).
When the function exported from the module is executed there is no any worker ready yet. Because of that `process.env.JEST_WORKER_ID` returns `undefined` and then method `getDynalitePort` returns `NaN`.
