### PR TITLE
fix: inaccessible host: "[hostname]" at port "[port]"

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -3,7 +3,6 @@ import { Config } from "./types";
 import { getDynalitePort, setConfigDir } from "./config";
 
 const BASE_PORT = 8443;
-const DEFAULT_BASE_PORT = 8000;
 
 const mockedConfig = jest.fn((): Config => ({ basePort: BASE_PORT }));
 const configPath = "/fakepath/jest-dynalite-config.js";
@@ -40,18 +39,21 @@ describe("Config", () => {
     const port = getDynalitePort();
 
     expect(port).not.toBeNaN();
-    expect(port).toBe(BASE_PORT);
+    expect(port).toBe(BASE_PORT + 1);
 
     process.env.JEST_WORKER_ID = workerId;
   });
 
-  test("if basePort is not defined then port 8000 will be used as a default", () => {
+  test("if basePort is not defined then port 8001 will be used as a default", () => {
+    const workerId = process.env.JEST_WORKER_ID;
+    delete process.env.JEST_WORKER_ID;
+
     jest.resetModules();
     mockedConfig.mockReturnValue({});
-    const expectedPort =
-      DEFAULT_BASE_PORT + parseInt(process.env.JEST_WORKER_ID || "0", 10);
 
-    expect(getDynalitePort()).toBe(expectedPort);
+    expect(getDynalitePort()).toBe(8001);
+
+    process.env.JEST_WORKER_ID = workerId;
   });
 
   test("should throw an error if basePort in config file is invalid", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,7 +67,7 @@ export const setConfigDir = (directory: string): void => {
 export const getDynalitePort = (): number => {
   const { basePort = 8000 } = readConfig();
   if (Number.isInteger(basePort) && basePort > 0 && basePort <= 65535) {
-    return basePort + parseInt(process.env.JEST_WORKER_ID || "0", 10);
+    return basePort + parseInt(process.env.JEST_WORKER_ID || "1", 10);
   }
 
   throw new TypeError(


### PR DESCRIPTION
Unfortunately, in #81 I introduced a bug. 

There is an error, when [--watch](https://jestjs.io/docs/cli#--watch) flag is used and the Dynalite is started **only once** before all tests cases.

When the server is starting there is **no** worker ready yet, so it starts on `basePort`, 
**but** after rerun workers are available and the server is wanted at `basePort + worker ID`. 

This produces the following error: 

> Inaccessible host: `localhost' at port `8000'. This service may not be available in the `local' region.