### PR TITLE
Add v3 client credentials config

### DIFF
--- a/src/dynamodb/v3.ts
+++ b/src/dynamodb/v3.ts
@@ -17,6 +17,10 @@ const dbConnection = (port: number): Connection => {
     endpoint: `http://localhost:${port}`,
     sslEnabled: false,
     region: "local",
+    credentials: {
+      accessKeyId: "accessKeyId",
+      secretAccessKey: "secretAccessKey",
+    },
   };
 
   connection = {


### PR DESCRIPTION
I am using AWS SSO and I get an error when the SSO token is expired during integration tests. Adding dummy credentials to the client options fixes the issue.

```
   CredentialsProviderError: The SSO session associated with this profile has expired. To refresh this SSO session run aws sso login with the corresponding profile.

      at resolveSSOCredentials (node_modules/@aws-sdk/credential-provider-sso/dist-cjs/resolveSSOCredentials.js:33:15)
      at node_modules/@smithy/property-provider/dist-cjs/chain.js:12:33
      at coalesceProvider (node_modules/@smithy/property-provider/dist-cjs/memoize.js:14:24)
      at SignatureV4.credentialProvider (node_modules/@smithy/property-provider/dist-cjs/memoize.js:33:24)
      at SignatureV4.signRequest (node_modules/@smithy/signature-v4/dist-cjs/SignatureV4.js:106:29)
      at node_modules/@aws-sdk/middleware-signing/dist-cjs/awsAuthMiddleware.js:16:18
      at node_modules/@smithy/middleware-retry/dist-cjs/retryMiddleware.js:27:46
      at node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
          at async Promise.all (index 0)
      at node_modules/jest-dynalite/dist/dynamodb/v3.js:68:5
```